### PR TITLE
Update link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This has been relocated to <https://github.com/github/teach.github.com>
+This has been relocated to <https://training.github.com>


### PR DESCRIPTION
The O'Reilly page for Mastering Advanced Git linked
here, which in turn linked to https://teach.github.com,
which in turn linked to https://training.github.com.
This eliminates one of those steps.
